### PR TITLE
Add docstrings to transcribe module

### DIFF
--- a/voskcli/transcribe.py
+++ b/voskcli/transcribe.py
@@ -28,6 +28,15 @@ MAX_LINES_IN_PARAGRAPH = 2
 
 
 def time_string(seconds):
+    '''
+    Convert time in seconds to a string containing hours,
+    minutes and seconds.
+
+    :param seconds: Time in seconds
+    :type seconds: float
+    :return: Time in format h:mm:ss.f
+    :rtype: str
+    '''
     minutes = seconds / 60
     seconds = seconds % 60
     hours = int(minutes / 60)
@@ -67,6 +76,25 @@ def model_path(model):
 
 
 def write_captions_paragraph(vtt, paragraph):
+    '''
+    Append time-coded paragraphs to vtt file.
+
+    :param vtt: Empty or partially filled WebVTT object to write
+        transcriptions to
+    :type vtt: WebVTT object
+    :param paragraph: Transcription data segment representing a single
+        paragraph as a list of lists, which contain python dictionaries.
+        Each inner list represents a single line of a paragraph,
+        while the dictionaries each represent a single word of that line.
+        Dictionary entries contain the following keys:
+
+        * conf: Confidence coefficient for the transcribed word (float)
+        * end: End time of transcribed word in seconds (float)
+        * start: Start time of transcribed word in seconds (float)
+        * word: Transcribed word (string)
+
+    :type paragraph: list
+    '''
     start = time_string(paragraph[0][0]['start'])
     end = time_string(paragraph[-1][-1]['end'])
     content = ''
@@ -79,6 +107,21 @@ def write_captions_paragraph(vtt, paragraph):
 
 
 def write_webvtt_captions(rec_results):
+    '''
+    Process transcription data.
+
+    Split transcription data into lines of up to MAX_CHARS_PER_LINE chars
+    and MAX_LINES_IN_PARAGRAPH lines and append paragraphs to vtt file.
+
+    :param rec_results: Complete segmented list of python dictionaries,
+        containing transcription data.
+        Data includes nested lists of dictionaries,
+        which contain time-coded entries for each transcribed word.
+        To access these, use key `result`.
+    :type rec_results: list
+    :return: WebVTT object containing formatted captions
+    :rtype: WebVTT object
+    '''
     vtt = WebVTT()
     line = []
     paragraph = []
@@ -122,7 +165,19 @@ def write_webvtt_captions(rec_results):
 
 
 def transcribe(inputFile, outputFile, model):
+    '''
+    Produce transcription.
 
+    Create transcription data from inputFile, process data
+    and save finished transcription to outputFile.
+
+    :param inputFile: Path to input file
+    :type inputFile: str
+    :param outputFile: Path to output file
+    :type outputFile: str
+    :param model: Path to model directory
+    :type model: str
+    '''
     print(f'Start transcribing with model {model}')
     sample_rate = 16000
     model = Model(model)
@@ -152,6 +207,9 @@ def transcribe(inputFile, outputFile, model):
 
 
 def main():
+    '''
+    Define arguments for command line usage and carry out transcription.
+    '''
     parser = ArgumentParser(description='Creates a WebVTT file out of a '
                             'media file with an audio track.')
     parser.add_argument('-i', type=str, dest='inputFile', required=True,


### PR DESCRIPTION
This patch adds docstrings to each function in the `transcribe` module.
I am a little unsure about a couple of things:

1.  Are these too detailled? not detailled enough?
2. Is it common/good practice to reference other functions in a docstring?
3. What would be the correct type of `WebVTT`?
4. Pretty sure the summary line of the `main` function's docstring is redundant.