### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,45 @@
 # vosk-cli
 
-This python package serves as an Vosk interface for Opencast. It allows to generate subtitles (WebVVT files) from Video and Audio sources via Vosk.
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/elan-ev/vosk-cli/Build%20and%20publish)
+![GitHub](https://img.shields.io/github/license/elan-ev/vosk-cli)
+![PyPI](https://img.shields.io/pypi/v/vosk-cli)
+
+This python package serves as an Vosk interface for Opencast. It allows to generate subtitles (WebVTT files) from Video and Audio sources via Vosk.
 
 ## Installation
 
 ### 1. Install vosk-cli
-
-Clone this project and run
+To install the [latest stable version of vosk-cli](https://pypi.org/project/vosk-cli/), run
 
 ```
-python setup.py install
+pip install vosk-cli
+```
+
+Alternatively, to install the latest development version, clone this project and inside the project directory run
+
+```
+pip install .
 ```
 
 ### 2. Install dependencies
-
 - FFmpeg
-- `pip install -r requirements.txt`
+
+vosk-cli uses ffmpeg to preprocess input files. The easiest way to install ffmpeg is by using a package manager.
+If you want or need to install from source, visit
+[FFmpeg.org/download.html](https://ffmpeg.org/download.html) and follow the instructions for your operating system.
 
 ### 3. Download the language model
 
-Go to `https://alphacephei.com/vosk/models` and download at least the English language model.
+Go to [https://alphacephei.com/vosk/models](https://alphacephei.com/vosk/models) and download at least the English language model. The larger models generally yield better results.
 
-Unzip the folder of the language model into `/usr/share/vosk/language/***`, and rename the folder from `***` to `eng` for example.
-Please use 3 digit language codes for the directory name. The default and fallback language directory of vosk-cli is `eng`.
-The directory name should match the workflow operation field `language-code`.
+You can unzip the folder of the language model into any directory, but it is recommended to create and use a `./models` folder in the project directory.
 
-Now you are able to run `vosk-cli -i <input_file_path> -o <output_file_path> -l <3_digit_language_code>`.
+## Usage
+
+Now you are able to run `vosk-cli -i <input_file_path> -o <output_file_path> -m <model_name_or_path>`.
+
+For example, if there is a `video.mp4` file in your download folder and a model named `vosk-model-en-us-0.22` in the `./models` folder you created, you can run
+
+`vosk-cli -i ~/Downloads/video.mp4 -o text -m vosk-model-en-us-0.22`
+
+This will create a `text.vtt` file (which contains the transcribed captions) in your current directory.


### PR DESCRIPTION
This updates the readme with an instruction to install vosk-cli directly from PyPI.
It also features an updated instruction to install from source. The recommended way of doing this is now `pip install .`, which will also install the dependencies from `requirements.txt`. Therefore the `Install dependencies` section now only features instructions to install ffmpeg.
The section about the language model download was slightly changed and now instructs the user to unzip their model in a `./models` directory instead of `usr/local...`, to reflect recent code changes. A fourth section was added to give a more detailed explanation on how to use vosk-cli.