### PR TITLE
Run bandit as part of the linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,3 +20,9 @@ jobs:
 
       - name: Run flake8
         run: flake8 setup.py voskcli
+
+      - name: Install bandit
+        run: pip install bandit
+
+      - name: Run bandit
+        run: bandit -s B404,B603 -r voskcli


### PR DESCRIPTION
As suggested in #16, this adds bandit to the linting process, ignoring rules that have been deemed non-issues