### PR TITLE
Fix Package Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include scripts/language_packs *
+include LICENSE README.md requirements.txt


### PR DESCRIPTION
This patch fixes the package manifest including files like the `requiements.txt` which is actually required for installing this package but which was not included in the package.