### PR TITLE
Fix Single Language Specification

### DIFF
--- a/voskcli/transcribe.py
+++ b/voskcli/transcribe.py
@@ -392,6 +392,6 @@ def main():
     if model == ['auto'] or len(model) > 1:
         model = detect_model(inputFile, model, args.probeTime)
     else:
-        model = model_path(args.model[0])
+        model = model_path(model[0])
 
     transcribe(inputFile, outputFile, model)


### PR DESCRIPTION
This patch fixes a crash when only a single language is specified. This is caused by the code trying to use the model command line argument instead of the model determined by the specified language.