### PR TITLE
Fix absolute path detection with empty path components.

### DIFF
--- a/voskcli/transcribe.py
+++ b/voskcli/transcribe.py
@@ -80,7 +80,7 @@ def model_path(model):
     '''
     # Do we have an absolute path to a directory?
     absmodel = os.path.abspath(model)
-    if model.startswith(absmodel):
+    if os.path.normpath(model).startswith(absmodel):
         if os.path.isdir(model):
             return model
         raise ValueError(f'Model path {model} does not exist')


### PR DESCRIPTION
Fixes #27.

Untested. But should be simple enough.

https://docs.python.org/3/library/os.path.html#os.path.abspath https://docs.python.org/3/library/os.path.html#os.path.normpath

Note Python docs explicitly specify that `abspath()` usually includes a transform that is equivalent to `normpath`.

Perhaps also note comment in Python docs that this "may change the meaning of a path that contains symbolic links".

…Actually, why is it `.startswith()` instead of `==`, or even just `.startswith('/')`— or `path.isabs()`— anyway?